### PR TITLE
Minor fix to OpenFFMol

### DIFF
--- a/mmic_openff/components/ff_component.py
+++ b/mmic_openff/components/ff_component.py
@@ -5,13 +5,18 @@ from mmic_translator import (
     TransInput,
     TransOutput,
 )
-from mmic_openff.mmic_openff import __version__
 from mmic.components import TacticComponent
 from cmselemental.util.decorators import classproperty
 from openff.toolkit.typing.engines import smirnoff
 
 from collections.abc import Iterable
 from typing import List, Tuple, Optional, Dict, Any, Set
+
+from mmic_openff.mmic_openff import (
+    __version__,
+    _supported_versions,
+    _mmschema_max_version,
+)
 
 provenance_stamp = {
     "creator": "mmic_openff",
@@ -33,15 +38,22 @@ class FFToOpenFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
+    @classproperty
+    def version(cls) -> str:
+        """Returns distutils-style version string.
+
+        Examples
+        --------
+        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
+        is compatible, except 1.5.1
+
         Returns
         -------
         str
-            Return a valid, safe python version string.
+            Return a dist-utils valid version string.
+
         """
-        raise NotImplementedError
+        return _supported_versions
 
     @classproperty
     def strategy_comps(cls) -> Set[str]:
@@ -314,15 +326,22 @@ class OpenFFToFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
+    @classproperty
+    def version(cls) -> str:
+        """Returns distutils-style version string.
+
+        Examples
+        --------
+        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
+        is compatible, except 1.5.1
+
         Returns
         -------
         str
-            Return a valid, safe python version string.
+            Return a dist-utils valid version string.
+
         """
-        raise NotImplementedError
+        return _supported_versions
 
     @classproperty
     def strategy_comps(cls) -> Set[str]:

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -87,12 +87,6 @@ class MolToOpenFFComponent(TacticComponent):
 
         mm_mol = inputs.schema_object
         ndim = mm_mol.ndim
-
-        if ndim != 3:
-            raise NotImplementedError(
-                "{creator} supports only 3D molecules.".format(**provenance_stamp)
-            )  # need to double check this
-
         mol = OffMolecule()
         mol.name = mm_mol.name
         natoms = len(mm_mol.symbols)

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -37,8 +37,8 @@ class MolToOpenFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
+    @classproperty
+    def version(cls) -> str:
         """Returns distutils-style version string.
 
         Examples
@@ -206,8 +206,8 @@ class OpenFFToMolComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
+    @classproperty
+    def version(cls) -> str:
         """Returns distutils-style version string.
 
         Examples

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -98,7 +98,6 @@ class MolToOpenFFComponent(TacticComponent):
                 )  # need to double check this
             )
 
-
         # For now, get any field not supported by MMSchema from extras
         extras = getattr(mm_mol, "extras", {}) or {}
         off_mol_unsupport = extras.get(provenance_stamp["creator"], {})
@@ -131,9 +130,7 @@ class MolToOpenFFComponent(TacticComponent):
                 is_aromatic=False if is_aromatic is None else is_aromatic[index],
                 formal_charge=0
                 if mm_mol.formal_charges is None
-                else formal_charges[
-                    index
-                ],
+                else formal_charges[index],
             )
 
         # Attach chemical bonds

--- a/mmic_openff/models/ff.py
+++ b/mmic_openff/models/ff.py
@@ -47,10 +47,12 @@ class OpenFFSmirnoff(ToolkitModel):
             The forcefield filename to read
         **kwargs
             Any additional keywords to pass to the constructor
+
         Returns
         -------
         OpenFFSmirnoff
             A constructed OpenFFSmirnoff object.
+
         """
         ff = cls.dtype(filename, **kwargs)
 
@@ -82,7 +84,7 @@ class OpenFFSmirnoff(ToolkitModel):
             "keywords": kwargs,
         }
         out = FFToOpenFFComponent.compute(inputs)
-        return cls(data=out.data_object, units=out.data_units)
+        return cls(data=out.data_object, data_units=out.data_units)
 
     def to_file(self, filename: str, dtype: str = None, **kwargs):
         """Writes the forcefield to a file.

--- a/mmic_openff/models/mol.py
+++ b/mmic_openff/models/mol.py
@@ -1,9 +1,6 @@
 from typing import Dict, Any, Optional
 from mmic_translator.models import ToolkitModel
 from mmelemental.models import Molecule
-from cmselemental.types import Array
-import numpy
-from pydantic import Field
 from pathlib import Path
 
 # Import OpenFF stuff
@@ -93,7 +90,7 @@ class OpenFFMol(ToolkitModel):
             "keywords": kwargs,
         }
         out = MolToOpenFFComponent.compute(inputs)
-        return cls(data=out.data_object, units=out.data_units)
+        return cls(data=out.data_object, data_units=out.data_units)
 
     def to_file(self, filename: str, dtype: str = None, mode: str = None, **kwargs):
         """Writes the molecule to a file.

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -13,12 +13,11 @@ import mm_data
 
 forcefields = [
     "openff-2.0.0.offxml",
-    #    pytest.param(mm_data.ffs["amber99sb.xml"], marks=pytest.mark.skip),
+    pytest.param(mm_data.ffs["amber99sb.xml"], marks=pytest.mark.skip),
 ]
 
 
-#@pytest.mark.parametrize("ff", forcefields)
-@pytest.mark.skip("Skip temporarily.")
+@pytest.mark.parametrize("ff", forcefields)
 def test_mmic_to_ff_from_xml(ff, **kwargs):
     inputs = {
         "data_object": ForceField(ff),

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -17,7 +17,8 @@ forcefields = [
 ]
 
 
-@pytest.mark.parametrize("ff", forcefields)
+#@pytest.mark.parametrize("ff", forcefields)
+@pytest.mark.skip("Skip temporarily.")
 def test_mmic_to_ff_from_xml(ff, **kwargs):
     inputs = {
         "data_object": ForceField(ff),


### PR DESCRIPTION
## Description
- Fixes minor bug with `data_units` in `OpenFFMol.from_schema` and removes unused imports.
- Replaces class method `get_version` with class property `version` in all components (requires mmic v0.1.1)
- Allows non-3D molecules (since conformations are not required).

## Status
- [x] Ready to go