### PR TITLE
1st pass for FF component + improvements to MOL converter

### DIFF
--- a/mmic_openff/components/ff_component.py
+++ b/mmic_openff/components/ff_component.py
@@ -1,6 +1,5 @@
 from mmelemental.models import forcefield
 from mmelemental.util import units
-from mmelemental.util.units import convert
 from mmic_translator import (
     InputTrans,
     OutputTrans,
@@ -13,6 +12,11 @@ from openff.toolkit.utils import string_to_quantity, quantity_to_string
 from openff.toolkit.utils.exceptions import SMIRNOFFParseError
 from collections.abc import Iterable
 from typing import List, Tuple, Optional, Dict, Any, Set
+from .ff_component_helper import (
+    OpenFFToFFComponentHelper,
+    FFToOpenFFComponentHelper,
+    pint_to_openmm,
+)
 
 from mmic_openff.mmic_openff import (
     __package__,
@@ -25,16 +29,6 @@ provenance_stamp = {
     "creator": __package__,
     "version": __version__,
     "routine": __name__,
-}
-
-_dihedrals_potentials_map = {
-    "k*(1+cos(periodicity*theta-phase))": "CharmmMulti",
-    # need to add all supported potentials in OpenFFTk
-}
-
-_dihedrals_improper_potentials_map = {
-    "k*(1+cos(periodicity*theta-phase))": "CharmmMulti",
-    # need to add all supported potentials in OpenFFTk
 }
 
 __all__ = ["FFToOpenFFComponent", "OpenFFToFFComponent"]
@@ -102,19 +96,19 @@ class FFToOpenFFComponent(TacticComponent):
             )
 
         # Get library charges
-        try:
-            charge_units = getattr(openmm_unit, mmff.charges_units)
-        except AttributeError:
-            raise AttributeError(f"OpenMM unit does not support {mmff.charges_units}.")
-
         off_charges = [
-            quantity_to_string(openmm_unit.Quantity(charge, unit=charge_units))
+            quantity_to_string(
+                pint_to_openmm(units.Quantity(charge, units=mmff.charges_units))
+            )
             for charge in mmff.charges
         ]
         charges = [
             {"smirks": mmff.defs[i], "charge1": off_charges[i], "name": mmff.symbols[i]}
             for i in range(len(off_charges))
         ]  # need to distinguish name from id
+
+        bonds = FFToOpenFFComponentHelper._get_bonds(mmff.bonds)
+        angles = FFToOpenFFComponentHelper._get_angles(mmff.angles)
 
         smirnoff_data = {
             "SMIRNOFF": {
@@ -127,8 +121,8 @@ class FFToOpenFFComponent(TacticComponent):
                     "aromaticity_model", "OEAroModel_MDL"
                 ),  # must generalize this
                 "Constraints": unsupported.get("Constraints"),
-                # "Bonds": ...,
-                # "Angles": ...,
+                "Bonds": bonds,
+                "Angles": angles,
                 # "ProperTorsions": ...,
                 # "ImproperTorsions": ...,
                 # "vdW": ...,
@@ -213,7 +207,7 @@ class OpenFFToFFComponent(TacticComponent):
 
         # VdW/coulomb data
         vdW_data = ff_data["vdW"]
-        nonbonded = self._get_nonbonded(vdW_data)
+        nonbonded = OpenFFToFFComponentHelper._get_nonbonded(vdW_data)
         libdata = [
             (
                 item["smirks"],
@@ -228,13 +222,15 @@ class OpenFFToFFComponent(TacticComponent):
 
         # Bonded data
         bonds_data = ff_data["Bonds"]
-        bonds = self._get_bonds(bonds_data)
+        bonds = OpenFFToFFComponentHelper._get_bonds(bonds_data)
         angles_data = ff_data["Angles"]
-        angles = self._get_angles(angles_data)
+        angles = OpenFFToFFComponentHelper._get_angles(angles_data)
         dihedrals_data = ff_data["ProperTorsions"]
-        dihedrals = self._get_dihedrals_proper(dihedrals_data)
+        dihedrals = OpenFFToFFComponentHelper._get_dihedrals_proper(dihedrals_data)
         dihedrals_improper_data = ff_data["ImproperTorsions"]
-        dihedrals_improper = self._get_dihedrals_improper(dihedrals_improper_data)
+        dihedrals_improper = OpenFFToFFComponentHelper._get_dihedrals_improper(
+            dihedrals_improper_data
+        )
 
         exclusions = None  # need to read these
         inclusions = None  # not available in OpenFF?
@@ -281,308 +277,4 @@ class OpenFFToFFComponent(TacticComponent):
             success=success,
             schema_version=inputs.schema_version,
             schema_name=inputs.schema_name,
-        )
-
-    def _get_nonbonded(self, vdW: Dict[str, Any]):
-
-        # Need to read scale12, scale13, ...
-        if vdW["potential"] != "Lennard-Jones-12-6":
-            raise NotImplementedError(
-                "mmic_openff supports only Lennard-Jones-12-6 potential for now."
-            )
-
-        atoms = vdW["Atom"]
-
-        scaling_factor = 2.0 / 2.0 ** (1.0 / 6.0)  # rmin_half = 2^(1/6) * sigma / 2
-
-        data = [
-            (
-                atom["smirks"],
-                atom["id"],
-                string_to_quantity(atom["epsilon"])._value,
-                string_to_quantity(atom["rmin_half"])._value * scaling_factor
-                if "rmin_half" in atom
-                else string_to_quantity(atom.get("sigma"))._value,
-            )
-            for atom in atoms
-        ]
-        defs, ids, epsilon, sigma = zip(*data)
-
-        # Pint raises UndefinedUnitError if this fails
-        single_atom = atoms[0]  # does the unit change with every atom?
-        epsilon_units = str(units.Quantity(single_atom["epsilon"]).u)
-        sigma_units = str(
-            units.Quantity(single_atom.get("rmin_half", single_atom.get("sigma"))).u
-        )
-
-        lj = forcefield.nonbonded.potentials.LennardJones(
-            sigma=sigma,
-            sigma_units=sigma_units,
-            epsilon=epsilon,
-            epsilon_units=epsilon_units,
-        )
-
-        nonbonded = forcefield.nonbonded.NonBonded(
-            params=lj,
-            form="LennardJones",
-            defs=defs,
-            combination_rule=vdW["combining_rules"],
-            version=vdW["version"],
-            extras={
-                __package__: {
-                    "ids": ids,
-                    "method": vdW["method"],
-                    "cutoff": vdW["cutoff"],
-                    "switch_width": vdW["switch_width"],
-                },
-            },
-        )
-
-        return nonbonded
-
-    def _get_bonds(self, bonds: Dict[str, Any]):
-        potential = getattr(
-            forcefield.bonded.bonds.potentials, bonds["potential"].capitalize(), None
-        )  # MMSchema always uses capitalized potential name
-        if not potential:
-            raise NotImplementedError(
-                f"Potential {bonds['potential']} not supported by MMSchema."
-            )
-
-        bonds_units = potential.default_units
-        bonds_units.update(forcefield.bonded.Bonds.default_units)
-
-        data = [
-            (
-                bond["smirks"],
-                bond["id"],
-                string_to_quantity(bond["length"])._value,
-                string_to_quantity(bond["k"])._value,
-            )
-            for bond in bonds["Bond"]
-        ]
-        defs, ids, lengths, springs = zip(*data)
-
-        # Pint raises UndefinedUnitError if this fails
-        single_bond = bonds["Bond"][0]  # assume the unit remains constant
-        spring_units = str(units.Quantity(single_bond["k"]).u)
-        lengths_units = str(units.Quantity(single_bond["length"]).u)
-
-        params = potential(spring=springs, spring_units=spring_units)
-
-        return forcefield.bonded.Bonds(
-            version=bonds["version"],
-            params=params,
-            defs=defs,
-            lengths=lengths,
-            lengths_units=lengths_units,
-            form=potential.__name__,
-            extras={
-                __package__: {
-                    "fractional_bondorder_method": bonds["fractional_bondorder_method"],
-                    "fractional_bondorder_interpolation": bonds[
-                        "fractional_bondorder_interpolation"
-                    ],
-                    "id": ids,
-                },
-            },
-        )
-
-    def _get_angles(self, angles: Dict[str, Any]):
-        potential = getattr(
-            forcefield.bonded.angles.potentials, angles["potential"].capitalize(), None
-        )  # MMSchema always uses capitalized potential names
-        if not potential:
-            raise NotImplementedError(
-                f"Potential {angles['potential']} not supported by MMSchema."
-            )
-
-        # Get units for all physical properties
-        angles_units = potential.default_units
-        angles_units.update(forcefield.bonded.Angles.default_units)
-
-        data = [
-            (
-                angle["smirks"],
-                angle["id"],
-                string_to_quantity(angle["angle"])._value,
-                string_to_quantity(angle["k"])._value,
-            )
-            for angle in angles["Angle"]
-        ]
-        defs, ids, angles_, springs = zip(*data)
-
-        # Pint raises an UndefinedUnitError if this fails
-        single_angle = angles["Angle"][0]  # assume the unit remains constant
-        spring_units = str(units.Quantity(single_angle["k"]).u)
-        angles_units = str(units.Quantity(single_angle["angle"]).u)
-
-        params = potential(spring=springs, spring_units=spring_units)
-
-        return forcefield.bonded.Angles(
-            version=angles["version"],
-            params=params,
-            defs=defs,
-            angles=angles_,
-            angles_units=angles_units,
-            form=potential.__name__,
-            extras={
-                __package__: {
-                    "id": ids,
-                }
-            },
-        )
-
-    def _get_dihedrals_proper(self, dihedrals: Dict[str, Any]):
-        potential_name = _dihedrals_potentials_map.get(dihedrals["potential"], "")
-        potential = getattr(
-            forcefield.bonded.dihedrals.potentials, potential_name, None
-        )
-        if not potential:
-            raise NotImplementedError(
-                f"Potential {dihedrals['potential']} not supported by MMSchema."
-            )
-
-        # Get units for all physical properties
-        dihedrals_units = potential.default_units
-        dihedrals_units.update(forcefield.bonded.Dihedrals.default_units)
-
-        # Read specific FF data
-        data = [
-            (
-                dihedral["smirks"],
-                dihedral["id"],
-            )
-            for dihedral in dihedrals["Proper"]
-        ]
-        defs, ids = zip(*data)
-
-        no_terms = lambda dih, prop: len(
-            [... for key in dih.keys() if key.startswith(prop)]
-        )  # hackish?
-        data = [
-            (
-                [dihedral[f"idivf{i+1}"] for i in range(no_terms(dihedral, "idivf"))],
-                [
-                    dihedral[f"periodicity{i+1}"]
-                    for i in range(no_terms(dihedral, "periodicity"))
-                ],
-                [
-                    string_to_quantity(dihedral[f"phase{i+1}"])._value
-                    for i in range(no_terms(dihedral, "phase"))
-                ],
-                [
-                    string_to_quantity(dihedral[f"k{i+1}"])._value
-                    for i in range(no_terms(dihedral, "k"))
-                ],
-            )
-            for dihedral in dihedrals["Proper"]
-        ]
-        idivf, periodicity, phase, energy = zip(*data)
-
-        # Pint raises UndefinedUnitError if this fails
-        single_dihedral = dihedrals["Proper"][0]  # assume the unit remains constant
-        energy_units = str(units.Quantity(single_dihedral["k1"]).u)
-        phase_units = str(units.Quantity(single_dihedral["phase1"]).u)
-
-        params = potential(
-            energy=energy,
-            energy_units=energy_units,
-            periodicity=periodicity,
-            phase=phase,
-            phase_units=phase_units,
-        )
-
-        return forcefield.bonded.Dihedrals(
-            version=dihedrals["version"],
-            params=params,
-            defs=defs,
-            form=potential.__name__,
-            extras={
-                __package__: {
-                    "fractional_bondorder_method": dihedrals[
-                        "fractional_bondorder_method"
-                    ],
-                    "fractional_bondorder_interpolation": dihedrals[
-                        "fractional_bondorder_interpolation"
-                    ],
-                    "default_idivf": dihedrals["default_idivf"],
-                    "idivf": idivf,  # what does this represent?
-                },
-            },
-        )
-
-    def _get_dihedrals_improper(self, imdihedrals: Dict[str, Any]):
-        potential_name = _dihedrals_improper_potentials_map.get(
-            imdihedrals["potential"], ""
-        )
-        potential = getattr(
-            forcefield.bonded.dihedrals_improper.potentials, potential_name, None
-        )
-        if not potential:
-            raise NotImplementedError(
-                f"Potential {dihedrals['potential']} not supported by MMSchema."
-            )
-
-        # Get units for all physical properties
-        imdihedrals_units = potential.default_units
-        imdihedrals_units.update(forcefield.bonded.DihedralsImproper.default_units)
-
-        # Read specific FF data
-        data = [
-            (
-                imdihedral["smirks"],
-                imdihedral["id"],
-            )
-            for imdihedral in imdihedrals["Improper"]
-        ]
-        defs, ids = zip(*data)
-
-        no_terms = lambda imdih, prop: len(
-            [... for key in imdih.keys() if key.startswith(prop)]
-        )  # hackish?
-        data = [
-            (
-                [
-                    imdihedral[f"periodicity{i+1}"]
-                    for i in range(no_terms(imdihedral, "periodicity"))
-                ],
-                [
-                    string_to_quantity(imdihedral[f"phase{i+1}"])._value
-                    for i in range(no_terms(imdihedral, "phase"))
-                ],
-                [
-                    string_to_quantity(imdihedral[f"k{i+1}"])._value
-                    for i in range(no_terms(imdihedral, "k"))
-                ],
-            )
-            for imdihedral in imdihedrals["Improper"]
-        ]
-        periodicity, phase, energy = zip(*data)
-
-        # Pint raises UndefinedUnitError if this fails
-        single_imdihedral = imdihedrals["Improper"][
-            0
-        ]  # assume the unit remains constant
-        energy_units = str(units.Quantity(single_imdihedral["k1"]).u)
-        phase_units = str(units.Quantity(single_imdihedral["phase1"]).u)
-
-        params = potential(
-            energy=energy,
-            energy_units=energy_units,
-            periodicity=periodicity,
-            phase=phase,
-            phase_units=phase_units,
-        )
-
-        return forcefield.bonded.Dihedrals(
-            version=imdihedrals["version"],
-            params=params,
-            defs=defs,
-            form=potential.__name__,
-            extras={
-                __package__: {
-                    "default_idivf": imdihedrals["default_idivf"],
-                },
-            },
         )

--- a/mmic_openff/components/ff_component.py
+++ b/mmic_openff/components/ff_component.py
@@ -5,13 +5,18 @@ from mmic_translator import (
     TransInput,
     TransOutput,
 )
-from mmic_openff.mmic_openff import __version__
 from mmic.components import TacticComponent
 from cmselemental.util.decorators import classproperty
 from openff.toolkit.typing.engines import smirnoff
 
 from collections.abc import Iterable
 from typing import List, Tuple, Optional, Dict, Any, Set
+
+from mmic_openff.mmic_openff import (
+    __version__,
+    _supported_versions,
+    _mmschema_max_version,
+)
 
 provenance_stamp = {
     "creator": "mmic_openff",
@@ -33,15 +38,22 @@ class FFToOpenFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
+    @classproperty
+    def version(cls) -> str:
+        """Returns distutils-style version string.
+
+        Examples
+        --------
+        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
+        is compatible, except 1.5.1
+
         Returns
         -------
         str
-            Return a valid, safe python version string.
+            Return a dist-utils valid version string.
+
         """
-        raise NotImplementedError
+        return _supported_versions
 
     @classproperty
     def strategy_comps(cls) -> Set[str]:
@@ -314,15 +326,22 @@ class OpenFFToFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
-        """Finds program, extracts version, returns normalized version string.
+    @classproperty
+    def version(cls) -> str:
+        """Returns distutils-style version string.
+
+        Examples
+        --------
+        The string ">1.0, !=1.5.1, <2.0" implies any version after 1.0 and before 2.0
+        is compatible, except 1.5.1
+
         Returns
         -------
         str
-            Return a valid, safe python version string.
+            Return a dist-utils valid version string.
+
         """
-        raise NotImplementedError
+        return _supported_versions
 
     @classproperty
     def strategy_comps(cls) -> Set[str]:

--- a/mmic_openff/components/ff_component_helper.py
+++ b/mmic_openff/components/ff_component_helper.py
@@ -1,0 +1,416 @@
+from mmelemental.models import forcefield
+from mmelemental.util import units
+from openff.toolkit.utils import string_to_quantity, quantity_to_string
+from openmm import unit as openmm_unit
+from typing import Dict, Any
+from .potential_maps import (
+    _dihedrals_potentials_map,
+    _dihedrals_improper_potentials_map,
+)
+
+
+def pint_to_openmm(quant: "pint.unit.Quantity") -> openmm_unit.Quantity:
+    _, phys_units = quant.to_tuple()
+    openmm_quant = openmm_unit.Quantity(quant.magnitude)
+
+    try:
+        for unit, exp in phys_units:
+            openmm_quant *= getattr(openmm_unit, unit) ** exp
+
+    except AttributeError:
+        raise AttributeError(f"OpenMM unit does not support {str(quant.u)}.")
+
+    return openmm_quant
+
+
+class FFToOpenFFComponentHelper:
+    @classmethod
+    def _get_bonds(cls, bonds: Dict[str, Any]) -> Dict[str, Any]:
+        unsupported_bonds = bonds.extras.get(__package__)
+
+        if unsupported_bonds is None:
+            raise NotImplementedError(
+                f"{cls.__name__} currently does not work without additional OFF data: id, fractional_bondorder_method, ..."
+            )
+
+        springs = [
+            quantity_to_string(
+                pint_to_openmm(units.Quantity(spring, units=bonds.params.spring_units))
+            )
+            for spring in bonds.params.spring
+        ]
+
+        lengths = [
+            quantity_to_string(
+                pint_to_openmm(units.Quantity(length, units=bonds.lengths_units))
+            )
+            for length in bonds.lengths
+        ]
+
+        return {
+            "Bond": [
+                {
+                    "smirks": bonds.defs[i],
+                    "id": unsupported_bonds.get("id")[i],
+                    "k": springs[i],
+                    "length": lengths[i],
+                }
+                for i in range(len(bonds.defs))
+            ],
+            "version": bonds.version,
+            "potential": bonds.form.lower(),  # OFF potentials seem to be always in lower-case
+            "fractional_bondorder_method": unsupported_bonds.get(
+                "fractional_bondorder_method"
+            ),
+            "fractional_bondorder_interpolation": unsupported_bonds.get(
+                "fractional_bondorder_interpolation"
+            ),
+        }
+
+    @classmethod
+    def _get_angles(cls, angles: Dict[str, Any]) -> Dict[str, Any]:
+        unsupported_angles = angles.extras.get(__package__)
+
+        if unsupported_angles is None:
+            raise NotImplementedError(
+                f"{cls.__name__} currently does not work without additional OFF data: id."
+            )
+
+        springs = [
+            quantity_to_string(
+                pint_to_openmm(units.Quantity(spring, units=angles.params.spring_units))
+            )
+            for spring in angles.params.spring
+        ]
+
+        angles_ = [
+            quantity_to_string(
+                pint_to_openmm(units.Quantity(angle, units=angles.angles_units))
+            )
+            for angle in angles.angles
+        ]
+
+        return {
+            "Angle": [
+                {
+                    "smirks": angles.defs[i],
+                    "angle": angles_[i],
+                    "k": springs[i],
+                    "id": unsupported_angles.get("id")[i],
+                }
+                for i in range(len(angles.defs))
+            ],
+            "version": angles.version,
+            "potential": angles.form.lower(),  # OFF potentials seem to be always in lower-case
+        }
+
+
+class OpenFFToFFComponentHelper:
+    @classmethod
+    def _get_nonbonded(cls, vdW: Dict[str, Any]):
+
+        # Need to read scale12, scale13, ...
+        if vdW["potential"] != "Lennard-Jones-12-6":
+            raise NotImplementedError(
+                "mmic_openff supports only Lennard-Jones-12-6 potential for now."
+            )
+
+        atoms = vdW["Atom"]
+
+        scaling_factor = 2.0 / 2.0 ** (1.0 / 6.0)  # rmin_half = 2^(1/6) * sigma / 2
+
+        data = [
+            (
+                atom["smirks"],
+                atom["id"],
+                string_to_quantity(atom["epsilon"])._value,
+                string_to_quantity(atom["rmin_half"])._value * scaling_factor
+                if "rmin_half" in atom
+                else string_to_quantity(atom.get("sigma"))._value,
+            )
+            for atom in atoms
+        ]
+        defs, ids, epsilon, sigma = zip(*data)
+
+        # Pint raises UndefinedUnitError if this fails
+        single_atom = atoms[0]  # does the unit change with every atom?
+        epsilon_units = str(units.Quantity(single_atom["epsilon"]).u)
+        sigma_units = str(
+            units.Quantity(single_atom.get("rmin_half", single_atom.get("sigma"))).u
+        )
+
+        lj = forcefield.nonbonded.potentials.LennardJones(
+            sigma=sigma,
+            sigma_units=sigma_units,
+            epsilon=epsilon,
+            epsilon_units=epsilon_units,
+        )
+
+        nonbonded = forcefield.nonbonded.NonBonded(
+            params=lj,
+            form="LennardJones",
+            defs=defs,
+            combination_rule=vdW["combining_rules"],
+            version=vdW["version"],
+            extras={
+                __package__: {
+                    "ids": ids,
+                    "method": vdW["method"],
+                    "cutoff": vdW["cutoff"],
+                    "switch_width": vdW["switch_width"],
+                },
+            },
+        )
+
+        return nonbonded
+
+    @classmethod
+    def _get_bonds(cls, bonds: Dict[str, Any]):
+        potential = getattr(
+            forcefield.bonded.bonds.potentials, bonds["potential"].capitalize(), None
+        )  # MMSchema always uses capitalized potential name
+        if not potential:
+            raise NotImplementedError(
+                f"Potential {bonds['potential']} not supported by MMSchema."
+            )
+
+        bonds_units = potential.default_units
+        bonds_units.update(forcefield.bonded.Bonds.default_units)
+
+        data = [
+            (
+                bond["smirks"],
+                bond["id"],
+                string_to_quantity(bond["length"])._value,
+                string_to_quantity(bond["k"])._value,
+            )
+            for bond in bonds["Bond"]
+        ]
+        defs, ids, lengths, springs = zip(*data)
+
+        # Pint raises UndefinedUnitError if this fails
+        single_bond = bonds["Bond"][0]  # assume the unit remains constant
+        spring_units = str(units.Quantity(single_bond["k"]).u)
+        lengths_units = str(units.Quantity(single_bond["length"]).u)
+
+        params = potential(spring=springs, spring_units=spring_units)
+
+        return forcefield.bonded.Bonds(
+            version=bonds["version"],
+            params=params,
+            defs=defs,
+            lengths=lengths,
+            lengths_units=lengths_units,
+            form=potential.__name__,
+            extras={
+                __package__: {
+                    "fractional_bondorder_method": bonds["fractional_bondorder_method"],
+                    "fractional_bondorder_interpolation": bonds[
+                        "fractional_bondorder_interpolation"
+                    ],
+                    "id": ids,
+                },
+            },
+        )
+
+    @classmethod
+    def _get_angles(cls, angles: Dict[str, Any]):
+        potential = getattr(
+            forcefield.bonded.angles.potentials, angles["potential"].capitalize(), None
+        )  # MMSchema always uses capitalized potential names
+        if not potential:
+            raise NotImplementedError(
+                f"Potential {angles['potential']} not supported by MMSchema."
+            )
+
+        # Get units for all physical properties
+        angles_units = potential.default_units
+        angles_units.update(forcefield.bonded.Angles.default_units)
+
+        data = [
+            (
+                angle["smirks"],
+                angle["id"],
+                string_to_quantity(angle["angle"])._value,
+                string_to_quantity(angle["k"])._value,
+            )
+            for angle in angles["Angle"]
+        ]
+        defs, ids, angles_, springs = zip(*data)
+
+        # Pint raises an UndefinedUnitError if this fails
+        single_angle = angles["Angle"][0]  # assume the unit remains constant
+        spring_units = str(units.Quantity(single_angle["k"]).u)
+        angles_units = str(units.Quantity(single_angle["angle"]).u)
+
+        params = potential(spring=springs, spring_units=spring_units)
+
+        return forcefield.bonded.Angles(
+            version=angles["version"],
+            params=params,
+            defs=defs,
+            angles=angles_,
+            angles_units=angles_units,
+            form=potential.__name__,
+            extras={
+                __package__: {
+                    "id": ids,
+                }
+            },
+        )
+
+    @classmethod
+    def _get_dihedrals_proper(cls, dihedrals: Dict[str, Any]):
+        potential_name = _dihedrals_potentials_map.get(dihedrals["potential"], "")
+        potential = getattr(
+            forcefield.bonded.dihedrals.potentials, potential_name, None
+        )
+        if not potential:
+            raise NotImplementedError(
+                f"Potential {dihedrals['potential']} not supported by MMSchema."
+            )
+
+        # Get units for all physical properties
+        dihedrals_units = potential.default_units
+        dihedrals_units.update(forcefield.bonded.Dihedrals.default_units)
+
+        # Read specific FF data
+        data = [
+            (
+                dihedral["smirks"],
+                dihedral["id"],
+            )
+            for dihedral in dihedrals["Proper"]
+        ]
+        defs, ids = zip(*data)
+
+        no_terms = lambda dih, prop: len(
+            [... for key in dih.keys() if key.startswith(prop)]
+        )  # hackish?
+        data = [
+            (
+                [dihedral[f"idivf{i+1}"] for i in range(no_terms(dihedral, "idivf"))],
+                [
+                    dihedral[f"periodicity{i+1}"]
+                    for i in range(no_terms(dihedral, "periodicity"))
+                ],
+                [
+                    string_to_quantity(dihedral[f"phase{i+1}"])._value
+                    for i in range(no_terms(dihedral, "phase"))
+                ],
+                [
+                    string_to_quantity(dihedral[f"k{i+1}"])._value
+                    for i in range(no_terms(dihedral, "k"))
+                ],
+            )
+            for dihedral in dihedrals["Proper"]
+        ]
+        idivf, periodicity, phase, energy = zip(*data)
+
+        # Pint raises UndefinedUnitError if this fails
+        single_dihedral = dihedrals["Proper"][0]  # assume the unit remains constant
+        energy_units = str(units.Quantity(single_dihedral["k1"]).u)
+        phase_units = str(units.Quantity(single_dihedral["phase1"]).u)
+
+        params = potential(
+            energy=energy,
+            energy_units=energy_units,
+            periodicity=periodicity,
+            phase=phase,
+            phase_units=phase_units,
+        )
+
+        return forcefield.bonded.Dihedrals(
+            version=dihedrals["version"],
+            params=params,
+            defs=defs,
+            form=potential.__name__,
+            extras={
+                __package__: {
+                    "fractional_bondorder_method": dihedrals[
+                        "fractional_bondorder_method"
+                    ],
+                    "fractional_bondorder_interpolation": dihedrals[
+                        "fractional_bondorder_interpolation"
+                    ],
+                    "default_idivf": dihedrals["default_idivf"],
+                    "idivf": idivf,  # what does this represent?
+                },
+            },
+        )
+
+    @classmethod
+    def _get_dihedrals_improper(cls, imdihedrals: Dict[str, Any]):
+        potential_name = _dihedrals_improper_potentials_map.get(
+            imdihedrals["potential"], ""
+        )
+        potential = getattr(
+            forcefield.bonded.dihedrals_improper.potentials, potential_name, None
+        )
+        if not potential:
+            raise NotImplementedError(
+                f"Potential {dihedrals['potential']} not supported by MMSchema."
+            )
+
+        # Get units for all physical properties
+        imdihedrals_units = potential.default_units
+        imdihedrals_units.update(forcefield.bonded.DihedralsImproper.default_units)
+
+        # Read specific FF data
+        data = [
+            (
+                imdihedral["smirks"],
+                imdihedral["id"],
+            )
+            for imdihedral in imdihedrals["Improper"]
+        ]
+        defs, ids = zip(*data)
+
+        no_terms = lambda imdih, prop: len(
+            [... for key in imdih.keys() if key.startswith(prop)]
+        )  # hackish?
+        data = [
+            (
+                [
+                    imdihedral[f"periodicity{i+1}"]
+                    for i in range(no_terms(imdihedral, "periodicity"))
+                ],
+                [
+                    string_to_quantity(imdihedral[f"phase{i+1}"])._value
+                    for i in range(no_terms(imdihedral, "phase"))
+                ],
+                [
+                    string_to_quantity(imdihedral[f"k{i+1}"])._value
+                    for i in range(no_terms(imdihedral, "k"))
+                ],
+            )
+            for imdihedral in imdihedrals["Improper"]
+        ]
+        periodicity, phase, energy = zip(*data)
+
+        # Pint raises UndefinedUnitError if this fails
+        single_imdihedral = imdihedrals["Improper"][
+            0
+        ]  # assume the unit remains constant
+        energy_units = str(units.Quantity(single_imdihedral["k1"]).u)
+        phase_units = str(units.Quantity(single_imdihedral["phase1"]).u)
+
+        params = potential(
+            energy=energy,
+            energy_units=energy_units,
+            periodicity=periodicity,
+            phase=phase,
+            phase_units=phase_units,
+        )
+
+        return forcefield.bonded.Dihedrals(
+            version=imdihedrals["version"],
+            params=params,
+            defs=defs,
+            form=potential.__name__,
+            extras={
+                __package__: {
+                    "default_idivf": imdihedrals["default_idivf"],
+                },
+            },
+        )

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -87,12 +87,6 @@ class MolToOpenFFComponent(TacticComponent):
 
         mm_mol = inputs.schema_object
         ndim = mm_mol.ndim
-
-        if ndim != 3:
-            raise NotImplementedError(
-                "{creator} supports only 3D molecules.".format(**provenance_stamp)
-            )  # need to double check this
-
         mol = OffMolecule()
         mol.name = mm_mol.name
         natoms = len(mm_mol.symbols)

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -7,8 +7,8 @@ from openmm import (
 from typing import List, Tuple, Optional, Set
 from cmselemental.util.decorators import classproperty
 from mmic_translator import (
-    TransInput,
-    TransOutput,
+    InputTrans,
+    OutputTrans,
 )
 from mmic.components import TacticComponent
 from mmic.components.base.base_component import ProgramHarness
@@ -33,11 +33,11 @@ class MolToOpenFFComponent(TacticComponent):
 
     @classproperty
     def input(cls):
-        return TransInput
+        return InputTrans
 
     @classproperty
     def output(cls):
-        return TransOutput
+        return OutputTrans
 
     @classproperty
     def version(cls) -> str:
@@ -67,12 +67,12 @@ class MolToOpenFFComponent(TacticComponent):
 
     def execute(
         self,
-        inputs: TransInput,
+        inputs: InputTrans,
         extra_outfiles: Optional[List[str]] = None,
         extra_commands: Optional[List[str]] = None,
         scratch_name: Optional[str] = None,
         timeout: Optional[int] = None,
-    ) -> Tuple[bool, TransOutput]:
+    ) -> Tuple[bool, OutputTrans]:
 
         if isinstance(inputs, dict):
             inputs = self.input(**inputs)
@@ -178,7 +178,7 @@ class MolToOpenFFComponent(TacticComponent):
             mol.partial_charges = partial_charges
 
         success = True
-        return success, TransOutput(
+        return success, OutputTrans(
             proc_input=inputs,
             data_object=mol,
             success=success,
@@ -193,11 +193,11 @@ class OpenFFToMolComponent(TacticComponent):
 
     @classproperty
     def input(cls):
-        return TransInput
+        return InputTrans
 
     @classproperty
     def output(cls):
-        return TransOutput
+        return OutputTrans
 
     @classproperty
     def version(cls) -> str:
@@ -229,12 +229,12 @@ class OpenFFToMolComponent(TacticComponent):
 
     def execute(
         self,
-        inputs: TransInput,
+        inputs: InputTrans,
         extra_outfiles: Optional[List[str]] = None,
         extra_commands: Optional[List[str]] = None,
         scratch_name: Optional[str] = None,
         timeout: Optional[int] = None,
-    ) -> Tuple[bool, TransOutput]:
+    ) -> Tuple[bool, OutputTrans]:
 
         if isinstance(inputs, dict):
             inputs = self.input(**inputs)
@@ -301,7 +301,7 @@ class OpenFFToMolComponent(TacticComponent):
         )
 
         success = True
-        return success, TransOutput(
+        return success, OutputTrans(
             proc_input=inputs,
             schema_object=Molecule(**input_dict),
             success=success,

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -37,8 +37,8 @@ class MolToOpenFFComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
+    @classproperty
+    def version(cls) -> str:
         """Returns distutils-style version string.
 
         Examples
@@ -206,8 +206,8 @@ class OpenFFToMolComponent(TacticComponent):
     def output(cls):
         return TransOutput
 
-    @classmethod
-    def get_version(cls) -> str:
+    @classproperty
+    def version(cls) -> str:
         """Returns distutils-style version string.
 
         Examples

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -1,9 +1,7 @@
 from mmelemental.models import Molecule
 from openff.toolkit.topology.molecule import Molecule as OffMolecule
 from mmic_openff.mmic_openff import units as openff_units
-from openmm import (
-    unit as openmm_unit,
-)  # OpenMM should not be a requirement
+from openmm import unit as openmm_unit
 from typing import List, Tuple, Optional, Set
 from cmselemental.util.decorators import classproperty
 from mmic_translator import (

--- a/mmic_openff/components/mol_component.py
+++ b/mmic_openff/components/mol_component.py
@@ -98,7 +98,6 @@ class MolToOpenFFComponent(TacticComponent):
                 )  # need to double check this
             )
 
-
         # For now, get any field not supported by MMSchema from extras
         extras = getattr(mm_mol, "extras", {}) or {}
         off_mol_unsupport = extras.get(provenance_stamp["creator"], {})
@@ -131,9 +130,7 @@ class MolToOpenFFComponent(TacticComponent):
                 is_aromatic=False if is_aromatic is None else is_aromatic[index],
                 formal_charge=0
                 if mm_mol.formal_charges is None
-                else formal_charges[
-                    index
-                ],
+                else formal_charges[index],
             )
 
         # Attach chemical bonds

--- a/mmic_openff/components/potential_maps.py
+++ b/mmic_openff/components/potential_maps.py
@@ -1,0 +1,14 @@
+"""
+Provides maps between MMSchema and OpenFF potential types.
+TODO: make this more rigorous and expand the maps.
+"""
+
+_dihedrals_potentials_map = {
+    "k*(1+cos(periodicity*theta-phase))": "CharmmMulti",
+    # need to add all supported potentials in OpenFFTk
+}
+
+_dihedrals_improper_potentials_map = {
+    "k*(1+cos(periodicity*theta-phase))": "CharmmMulti",
+    # need to add all supported potentials in OpenFFTk
+}

--- a/mmic_openff/models/ff.py
+++ b/mmic_openff/models/ff.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional, Union, List
 from mmic_translator.models import ToolkitModel
 from mmelemental.models import ForceField
+from cmselemental.util.decorators import classproperty
 
 # Import Components
 from mmic_openff.components.ff_component import FFToOpenFFComponent
@@ -16,11 +17,11 @@ __all__ = ["OpenFFSmirnoff"]
 class OpenFFSmirnoff(ToolkitModel):
     """A model for storing a Smirnoff ForceField object in the OpenFF toolkit."""
 
-    @classmethod
+    @classproperty
     def engine(cls):
         return "openff", off_version
 
-    @classmethod
+    @classproperty
     def dtype(cls):
         """Returns the fundamental force field object type."""
         return ForceFieldSmirnoff

--- a/mmic_openff/models/ff.py
+++ b/mmic_openff/models/ff.py
@@ -47,10 +47,12 @@ class OpenFFSmirnoff(ToolkitModel):
             The forcefield filename to read
         **kwargs
             Any additional keywords to pass to the constructor
+
         Returns
         -------
         OpenFFSmirnoff
             A constructed OpenFFSmirnoff object.
+
         """
         ff = cls.dtype(filename, **kwargs)
 
@@ -82,7 +84,7 @@ class OpenFFSmirnoff(ToolkitModel):
             "keywords": kwargs,
         }
         out = FFToOpenFFComponent.compute(inputs)
-        return cls(data=out.data_object, units=out.data_units)
+        return cls(data=out.data_object, data_units=out.data_units)
 
     def to_file(self, filename: str, dtype: str = None, **kwargs):
         """Writes the forcefield to a file.

--- a/mmic_openff/models/mol.py
+++ b/mmic_openff/models/mol.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional
 from mmic_translator.models import ToolkitModel
 from mmelemental.models import Molecule
+from cmselemental.util.decorators import classproperty
 from pathlib import Path
 
 # Import OpenFF stuff
@@ -16,11 +17,11 @@ __all__ = ["OpenFFMol"]
 class OpenFFMol(ToolkitModel):
     """A model for OpenFF molecule class storing a molecule object."""
 
-    @classmethod
+    @classproperty
     def engine(cls):
         return "openff", off_version
 
-    @classmethod
+    @classproperty
     def dtype(cls):
         """Returns the fundamental molecule object type."""
         return off_top.Molecule
@@ -58,7 +59,7 @@ class OpenFFMol(ToolkitModel):
                 f"{cls} does not support passing topology filenames"
             )
 
-        mol = cls.dtype().from_file(filename, **kwargs)
+        mol = cls.dtype.from_file(filename, **kwargs)
 
         return cls(
             data=mol,

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -12,6 +12,7 @@ import mmelemental as mm
 import mm_data
 
 forcefields = [
+    "openff-1.2.0.offxml",
     "openff-2.0.0.offxml",
     pytest.param(mm_data.ffs["amber99sb.xml"], marks=pytest.mark.skip),
 ]

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -19,24 +19,30 @@ forcefields = [
 
 
 @pytest.mark.parametrize("ff", forcefields)
-def test_mmic_to_ff_from_xml(ff, **kwargs):
+def test_mmic_openff_from_xml(ff, **kwargs):
     inputs = {
         "data_object": ForceField(ff),
         "keywords": kwargs,
-        "schema_version": 1,
+        "schema_version": mmic_openff.mmic_openff._mmschema_max_version,
         "schema_name": mm.models.ForceField.default_schema_name,
     }
     return mmic_openff.components.OpenFFToFFComponent.compute(inputs)
 
 
-@pytest.mark.skip("Cannot test this right now.")
-def test_ff_to_openmm(**kwargs):
-    ff = mm.models.ForceField.from_file(amber99sb)
-    inputs = {"schema_object": ff, "keywords": kwargs}
+@pytest.mark.parametrize("ff", forcefields)
+def test_mmic_openff_from_mmschema(ff, **kwargs):
+    mmff = test_mmic_openff_from_xml(ff).schema_object
+    mmff = mm.models.ForceField(**mmff.dict())
+    inputs = {
+        "schema_object": mmff,
+        "schema_name": mmff.schema_name,
+        "schema_version": mmff.schema_version,
+        "keywords": kwargs,
+    }
     return mmic_openff.components.FFToOpenFFComponent.compute(inputs)
 
 
 @pytest.mark.skip
 def test_io_methods(**kwargs):
     ff = mmic_openff.models.OpenMMFF.from_file(amber99sb)
-    assert isinstance(ff.data, ff.dtype())
+    assert isinstance(ff.data, ff.dtype)

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -13,12 +13,11 @@ import mm_data
 
 forcefields = [
     "openff-2.0.0.offxml",
-    #    pytest.param(mm_data.ffs["amber99sb.xml"], marks=pytest.mark.skip),
+    pytest.param(mm_data.ffs["amber99sb.xml"], marks=pytest.mark.skip),
 ]
 
 
-#@pytest.mark.parametrize("ff", forcefields)
-@pytest.mark.skip("Skip temporarily.")
+@pytest.mark.parametrize("ff", forcefields)
 def test_mmic_to_ff_from_xml(ff, **kwargs):
     inputs = {
         "data_object": ForceField(ff),

--- a/mmic_openff/tests/test_mmic_openff_ff.py
+++ b/mmic_openff/tests/test_mmic_openff_ff.py
@@ -17,7 +17,8 @@ forcefields = [
 ]
 
 
-@pytest.mark.parametrize("ff", forcefields)
+#@pytest.mark.parametrize("ff", forcefields)
+@pytest.mark.skip("Skip temporarily.")
 def test_mmic_to_ff_from_xml(ff, **kwargs):
     inputs = {
         "data_object": ForceField(ff),

--- a/mmic_openff/tests/test_mmic_openff_mol.py
+++ b/mmic_openff/tests/test_mmic_openff_mol.py
@@ -58,7 +58,7 @@ def test_mol_to_openff(**kwargs):
 @pytest.mark.parametrize("mfile", molecules)
 def test_io_methods(mfile: str, **kwargs):
     omol = mmic_openff.models.OpenFFMol.from_file(mfile)
-    assert isinstance(omol.data, omol.dtype())
+    assert isinstance(omol.data, omol.dtype)
 
     omol.to_file("tmp.pdb")
     os.remove("tmp.pdb")

--- a/mmic_openff/tests/test_mmic_openff_mol.py
+++ b/mmic_openff/tests/test_mmic_openff_mol.py
@@ -7,7 +7,8 @@ import mmic_openff
 import pytest
 import sys
 import os
-
+from pathlib import Path
+import tempfile
 import mmelemental as mm
 import mm_data
 from mmic_openff.tests.util import get_files
@@ -60,8 +61,9 @@ def test_io_methods(mfile: str, **kwargs):
     omol = mmic_openff.models.OpenFFMol.from_file(mfile)
     assert isinstance(omol.data, omol.dtype)
 
-    omol.to_file("tmp.pdb")
-    os.remove("tmp.pdb")
+    file = tempfile.NamedTemporaryFile(suffix=".pdb")
+    omol.to_file(file.name)
+    assert Path(file.name).is_file()
 
     mmol = omol.to_schema(version=mmic_openff.mmic_openff._mmschema_max_version)
     assert isinstance(mmol, mm.models.Molecule)


### PR DESCRIPTION
## Description
- Completes `OpenFFToFFComponent`.
- Fixes minor bug with `data_units` in `OpenFFMol.from_schema` and removes unused imports.
- Replaces class method `get_version` with class property `version` in all components (requires mmic v0.1.1)
- Allows non-3D molecules (since conformations are not required).

## Status
- [x] Ready to go